### PR TITLE
Bugfix MultipleSubst1 GSUB subtable data loading

### DIFF
--- a/src/otl/lookup.rs
+++ b/src/otl/lookup.rs
@@ -500,7 +500,7 @@ impl fmt::Debug for Subtable<'_> {
 }
 
 /// Kind of a subtable.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum SubtableKind<'a> {
     /// Single substitution format 1.
     SingleSubst1(SingleSubst1<'a>),

--- a/src/otl/sub.rs
+++ b/src/otl/sub.rs
@@ -101,7 +101,7 @@ impl<'a> MultipleSubst1<'a> {
         let base = self.0.record.offset as usize;
         let array_base = base + data.read::<u16>(base + 6 + coverage as usize * 2)? as usize;
         let array_len = data.read::<u16>(array_base)? as usize;
-        data.read_slice::<u16>(array_base, array_len)
+        data.read_slice::<u16>(array_base + 2, array_len)
     }
 }
 


### PR DESCRIPTION
The offset for reading the slice of glyph indices wasn't compensating for the slice-length field.

Also implement Debug for SubtableKind.