### PR TITLE
changed hmetrics() to vmetrics().

### DIFF
--- a/src/vmtx.rs
+++ b/src/vmtx.rs
@@ -51,7 +51,7 @@ impl<'a> Vmtx<'a> {
     }
 
     /// Returns the slice of vertical metrics.
-    pub fn hmetrics(&self) -> Slice<'a, VMetric> {
+    pub fn vmetrics(&self) -> Slice<'a, VMetric> {
         self.data
             .read_slice(0, self.num_vmetrics as usize)
             .unwrap_or_default()


### PR DESCRIPTION
[vmtx.rs](https://github.com/dfrg/pinot/compare/master...ekicyou:pinot:master?expand=1#diff-7f1da366c8a040d2ebabcf04b5a0aacef64f3c5a2573449f972f41fb029dc2da)

changed hmetrics() to vmetrics().